### PR TITLE
Настройки Raven

### DIFF
--- a/cms/envs/npoed.py
+++ b/cms/envs/npoed.py
@@ -1,0 +1,11 @@
+from aws import *
+
+
+#  ENV_TOKENS file - cms.env.json; AUTH_TOKENS file - cms.auth.json
+# Sentry integration
+RAVEN_DSN = ENV_TOKENS.get('RAVEN_DSN', None)
+if RAVEN_DSN:
+    INSTALLED_APPS += ('raven.contrib.django.raven_compat',)
+    RAVEN_CONFIG = {
+        'dsn': RAVEN_DSN,
+    }

--- a/lms/envs/npoed.py
+++ b/lms/envs/npoed.py
@@ -1,0 +1,11 @@
+from aws import *
+
+
+#  ENV_TOKENS file - lms.env.json; AUTH_TOKENS file - lms.auth.json
+# Sentry integration
+RAVEN_DSN = ENV_TOKENS.get('RAVEN_DSN', None)
+if RAVEN_DSN:
+    INSTALLED_APPS += ('raven.contrib.django.raven_compat',)
+    RAVEN_CONFIG = {
+        'dsn': RAVEN_DSN,
+    }

--- a/openedx/core/lib/logsettings.py
+++ b/openedx/core/lib/logsettings.py
@@ -4,6 +4,7 @@ import os
 import platform
 import sys
 from logging.handlers import SysLogHandler
+from django.conf import settings
 
 LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
 
@@ -58,6 +59,8 @@ def get_logger_config(log_dir,
     handlers = ['console', 'local']
     if syslog_addr:
         handlers.append('syslogger-remote')
+    if 'RAVEN_DSN' in dir(settings):
+        handlers.append('sentry')
 
     logger_config = {
         'version': 1,
@@ -160,6 +163,26 @@ def get_logger_config(log_dir,
                 'address': '/dev/log',
                 'facility': SysLogHandler.LOG_LOCAL1,
                 'formatter': 'raw',
+            },
+        })
+
+    if 'RAVEN_DSN' in dir(settings):
+        logger_config['handlers'].update({
+            'sentry': {
+                'level': 'ERROR',
+                'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+            },
+        })
+        logger_config['loggers'].update({
+            'raven': {
+                'level': 'DEBUG',
+                'handlers': ['console', 'sentry'],
+                'propagate': False,
+            },
+            'sentry.errors': {
+                'level': 'DEBUG',
+                'handlers': ['console'],
+                'propagate': False,
             },
         })
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -156,3 +156,6 @@ analytics-python==0.4.4
 # Needed for mailchimp(mailing djangoapp)
 mailsnake==1.6.2
 jsonfield==1.0.3
+
+# npoed
+raven=5.5.0


### PR DESCRIPTION
Изменения в коде, которые позволят отправлять лог ошибок в Sentry. 
Необходимо внести настройки dsn вида:
"RAVEN_DSN": "http://....."
в файлы cms.envs.json и lms.envs.json